### PR TITLE
FEA Add `EngineAwareMixin` to factor the common logic of estimators which are plugin-extendable

### DIFF
--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -15,6 +15,7 @@ _global_config = {
     "enable_cython_pairwise_dist": True,
     "array_api_dispatch": False,
     "engine_provider": (),
+    "engine_attributes": "engine_types",
     "transform_output": "default",
 }
 _threadlocal = threading.local()
@@ -55,6 +56,7 @@ def set_config(
     enable_cython_pairwise_dist=None,
     array_api_dispatch=None,
     engine_provider=None,
+    engine_attributes=None,
     transform_output=None,
 ):
     """Set global scikit-learn configuration
@@ -133,6 +135,15 @@ def set_config(
 
         .. versionadded:: 1.3
 
+    engine_attributes : str, default=None
+        Enable conversion of estimator attributes to scikit-learn native
+        types by setting to "sklearn_types". By default attributes are
+        stored using engine native types.
+
+        See the :ref:`User Guide <engine>` for more details.
+
+        .. versionadded:: 1.3
+
     transform_output : str, default=None
         Configure output of `transform` and `fit_transform`.
 
@@ -168,6 +179,8 @@ def set_config(
         local_config["array_api_dispatch"] = array_api_dispatch
     if engine_provider is not None:
         local_config["engine_provider"] = engine_provider
+    if engine_attributes is not None:
+        local_config["engine_attributes"] = engine_attributes
     if transform_output is not None:
         local_config["transform_output"] = transform_output
 
@@ -183,6 +196,7 @@ def config_context(
     enable_cython_pairwise_dist=None,
     array_api_dispatch=None,
     engine_provider=None,
+    engine_attributes=None,
     transform_output=None,
 ):
     """Context manager for global scikit-learn configuration.
@@ -260,6 +274,15 @@ def config_context(
 
         .. versionadded:: 1.3
 
+    engine_attributes : str, default=None
+        Enable conversion of estimator attributes to scikit-learn native
+        types by setting to "sklearn_types". By default attributes are
+        stored using engine native types.
+
+        See the :ref:`User Guide <engine>` for more details.
+
+        .. versionadded:: 1.3
+
     transform_output : str, default=None
         Configure output of `transform` and `fit_transform`.
 
@@ -309,6 +332,7 @@ def config_context(
         enable_cython_pairwise_dist=enable_cython_pairwise_dist,
         array_api_dispatch=array_api_dispatch,
         engine_provider=engine_provider,
+        engine_attributes=engine_attributes,
         transform_output=transform_output,
     )
 

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -138,7 +138,9 @@ def set_config(
     engine_attributes : str, default=None
         Enable conversion of estimator attributes to scikit-learn native
         types by setting to "sklearn_types". By default attributes are
-        stored using engine native types.
+        stored using engine native types. This avoids additional conversions
+        and memory transfers between host and device when calling `predict`/
+        `transform` after `fit` of an engine-aware estimator.
 
         See the :ref:`User Guide <engine>` for more details.
 

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -2,6 +2,7 @@
 """
 import os
 from contextlib import contextmanager as contextmanager
+import inspect
 import threading
 
 _global_config = {
@@ -126,10 +127,10 @@ def set_config(
 
         .. versionadded:: 1.2
 
-    engine_provider : str or sequence of str, default=None
-        Enable computational engine implementation provided by third party
-        packages to leverage specific hardware platforms using frameworks or
-        libraries outside of the usual scikit-learn project dependencies.
+    engine_provider : str or sequence of {str, engine class}, default=None
+        Specify list of enabled computational engine implementations provided
+        by third party packages. Engines are enabled by listing the name of
+        the provider or listing an engine class directly.
 
         See the :ref:`User Guide <engine>` for more details.
 
@@ -180,6 +181,12 @@ def set_config(
     if array_api_dispatch is not None:
         local_config["array_api_dispatch"] = array_api_dispatch
     if engine_provider is not None:
+        # Single provider name was passed in
+        if isinstance(engine_provider, str):
+            engine_provider = (engine_provider,)
+        # Single engine class was passed in
+        elif inspect.isclass(engine_provider):
+            engine_provider = (engine_provider,)
         local_config["engine_provider"] = engine_provider
     if engine_attributes is not None:
         local_config["engine_attributes"] = engine_attributes
@@ -267,10 +274,10 @@ def config_context(
 
         .. versionadded:: 1.2
 
-    engine_provider : str or sequence of str, default=None
-        Enable computational engine implementation provided by third party
-        packages to leverage specific hardware platforms using frameworks or
-        libraries outside of the usual scikit-learn project dependencies.
+    engine_provider : str or sequence of {str, engine class}, default=None
+        Specify list of enabled computational engine implementations provided
+        by third party packages. Engines are enabled by listing the name of
+        the provider or listing an engine class directly.
 
         See the :ref:`User Guide <engine>` for more details.
 

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -184,7 +184,9 @@ def set_config(
         # Single provider name was passed in
         if isinstance(engine_provider, str):
             engine_provider = (engine_provider,)
-        # Single engine class was passed in
+        # Allow direct registration of engine classes to ease testing, debugging
+        # and benchmarking without having to register a fake package with metadata
+        # just to use a custom engine not meant to be used by end-users.
         elif inspect.isclass(engine_provider):
             engine_provider = (engine_provider,)
         local_config["engine_provider"] = engine_provider

--- a/sklearn/_engine/__init__.py
+++ b/sklearn/_engine/__init__.py
@@ -1,4 +1,4 @@
-from .base import get_engine_classes, list_engine_provider_names
+from .base import convert_attributes, get_engine_classes, list_engine_provider_names
 
 
-__all__ = ["get_engine_classes", "list_engine_provider_names"]
+__all__ = ["convert_attributes", "get_engine_classes", "list_engine_provider_names"]

--- a/sklearn/_engine/base.py
+++ b/sklearn/_engine/base.py
@@ -90,7 +90,10 @@ def _get_engine_classes(engine_name, provider_names, engine_specs, default):
             # we use the class itself. This mirrors what the user used
             # when they set the config (ad-hoc class or string naming
             # a provider).
-            yield provider_name, provider_name
+            engine_class = provider_name
+            if getattr(engine_class, "engine_name", None) != engine_name:
+                continue
+            yield engine_class, engine_class
 
         spec = specs_by_provider.get(provider_name)
         if spec is not None:

--- a/sklearn/_engine/base.py
+++ b/sklearn/_engine/base.py
@@ -137,6 +137,12 @@ def convert_attributes(method):
                 converted = engine.convert_to_sklearn_types(name, attribute)
                 setattr(self, name, converted)
 
+            # No matter which engine was used to fit, after the attribute
+            # conversion to the sklearn native types the default engine
+            # is used.
+            self._engine_class = self._default_engine
+            self._engine_provider = "default"
+
         return r
 
     return wrapper

--- a/sklearn/_engine/base.py
+++ b/sklearn/_engine/base.py
@@ -112,3 +112,8 @@ def get_engine_classes(engine_name, default, verbose=False):
                 f"trying engine {engine_class.__module__}.{engine_class.__qualname__} ."
             )
         yield provider, engine_class
+
+
+from functools import wraps
+def convert_attributes(estimator):
+    @wraps(f)

--- a/sklearn/_engine/base.py
+++ b/sklearn/_engine/base.py
@@ -115,11 +115,12 @@ def get_engine_classes(engine_name, default, verbose=False):
 
 
 def convert_attributes(method):
-    """Convert estimator attributes after calling the decorated method
+    """Convert estimator attributes after calling the decorated method.
 
     The attributes of an estimator can be stored in "engine native" types
-    (default) or "scikit-learn native" types. Decorate methods, like `fit`
-    that set attributes.
+    (default) or "scikit-learn native" types. This decorator will call the
+    engine's conversion function when needed. Use this decorator on methods
+    that set estimator attributes.
     """
 
     @wraps(method)
@@ -130,10 +131,11 @@ def convert_attributes(method):
         if convert_attributes == "sklearn_types":
             engine = self._engine_class
             for name, attribute in vars(self).items():
-                # Using __dlpack__ as signal for "not a basic Python type"
-                if hasattr(attribute, "__dlpack__"):
-                    converted = engine.convert_to_numpy(name, attribute)
-                    setattr(self, name, converted)
+                # All attributes are passed to the engine, which can
+                # either convert the value (engine specific types) or
+                # return it as is (native Python types)
+                converted = engine.convert_to_sklearn_types(name, attribute)
+                setattr(self, name, converted)
 
         return r
 

--- a/sklearn/_engine/base.py
+++ b/sklearn/_engine/base.py
@@ -130,11 +130,11 @@ def convert_attributes(method):
 
         if convert_attributes == "sklearn_types":
             engine = self._engine_class
-            for name, attribute in vars(self).items():
+            for name, value in vars(self).items():
                 # All attributes are passed to the engine, which can
                 # either convert the value (engine specific types) or
                 # return it as is (native Python types)
-                converted = engine.convert_to_sklearn_types(name, attribute)
+                converted = engine.convert_to_sklearn_types(name, value)
                 setattr(self, name, converted)
 
             # No matter which engine was used to fit, after the attribute

--- a/sklearn/_engine/tests/test_engines.py
+++ b/sklearn/_engine/tests/test_engines.py
@@ -29,6 +29,7 @@ class FakeEngineHolder:
 
 # Dummy classes used to test engine resolution
 class DefaultEngine:
+    engine_name = "test-engine"
     def __init__(self, estimator):
         self.estimator = estimator
 
@@ -37,6 +38,7 @@ class DefaultEngine:
 
 
 class NeverAcceptsEngine:
+    engine_name = "test-engine"
     def __init__(self, estimator):
         self.estimator = estimator
 
@@ -45,6 +47,7 @@ class NeverAcceptsEngine:
 
 
 class AlwaysAcceptsEngine:
+    engine_name = "test-engine"
     def __init__(self, estimator):
         self.estimator = estimator
 

--- a/sklearn/_engine/tests/test_engines.py
+++ b/sklearn/_engine/tests/test_engines.py
@@ -146,7 +146,13 @@ def test_get_engine_class():
     "attribute_types,converted", [("sklearn_types", True), ("engine_types", False)]
 )
 def test_attribute_conversion(attribute_types, converted):
+    """Test attribute conversion logic
+
+    The estimator uses Numpy Array API arrays as its native type.
+    """
+
     class Engine:
+        @staticmethod
         def convert_to_numpy(name, value):
             return np.asarray(value)
 
@@ -160,7 +166,6 @@ def test_attribute_conversion(attribute_types, converted):
     X = np.array([1, 2, 3])
     est = Estimator()
     with config_context(engine_attributes=attribute_types):
-        print("requested:", attribute_types)
         est.fit(X)
 
     assert isinstance(est.x, np.ndarray) == converted

--- a/sklearn/_engine/tests/test_engines.py
+++ b/sklearn/_engine/tests/test_engines.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 import pytest
 
 import numpy as np
-import numpy.array_api
 
 from sklearn._engine import convert_attributes
 from sklearn._engine import list_engine_provider_names
@@ -150,10 +149,11 @@ def test_attribute_conversion(attribute_types, converted):
 
     The estimator uses Numpy Array API arrays as its native type.
     """
+    np_array_api = pytest.importorskip("numpy.array_api")
 
     class Engine:
         @staticmethod
-        def convert_to_numpy(name, value):
+        def convert_to_sklearn_types(name, value):
             return np.asarray(value)
 
     class Estimator:
@@ -161,11 +161,11 @@ def test_attribute_conversion(attribute_types, converted):
 
         @convert_attributes
         def fit(self, X):
-            self.x = np.array_api.asarray(X)
+            self.X_ = np_array_api.asarray(X)
 
     X = np.array([1, 2, 3])
     est = Estimator()
     with config_context(engine_attributes=attribute_types):
         est.fit(X)
 
-    assert isinstance(est.x, np.ndarray) == converted
+    assert isinstance(est.X_, np.ndarray) == converted

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1004,17 +1004,24 @@ class EngineAwareMixin:
         again.
         """
         if hasattr(self, "_engine_provider") and not reset:
-            return self._engine_class(self)
+            return self._engine_class(self), {
+                "X": X,
+                "y": y,
+                "sample_weight": sample_weight,
+            }
 
         for provider, engine_class in get_engine_classes(
             self._engine_name,
             default=self._default_engine,
         ):
             engine = engine_class(self)
-            if engine.accepts(X, y=y, sample_weight=sample_weight):
+            accepted, validated_inputs = engine.validate(
+                X, y=y, sample_weight=sample_weight
+            )
+            if accepted:
                 self._engine_provider = provider
                 self._engine_class = engine_class
-                return engine
+                return engine, validated_inputs
 
 
 def is_classifier(estimator):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -994,6 +994,7 @@ class _UnstableArchMixin:
 
 class EngineAwareMixin:
     """Mixin for estimators that use a pluggable engine to do the work"""
+
     def _get_engine(self, X, y=None, sample_weight=None, reset=False):
         for provider, engine_class in get_engine_classes(
             self._engine_name,
@@ -1006,6 +1007,7 @@ class EngineAwareMixin:
             engine = engine_class(self)
             if engine.accepts(X, y=y):
                 self._engine_provider = provider
+                self._engine_class = engine_class
                 return engine
 
         if hasattr(self, "_engine_provider"):
@@ -1014,10 +1016,6 @@ class EngineAwareMixin:
                 f" {self._engine_provider} engine, but it is not available. Currently"
                 f" configured engines: {get_config()['engine_provider']}"
             )
-
-    def fit(self, X, y=None, sample_weight=None):
-        print("engine fitting")
-        return super().fit(X, y=y, sample_weight=sample_weight)
 
 
 def is_classifier(estimator):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -996,26 +996,25 @@ class EngineAwareMixin:
     """Mixin for estimators that use a pluggable engine to do the work"""
 
     def _get_engine(self, X, y=None, sample_weight=None, reset=False):
+        """Determine the engine for the estimator to use.
+
+        All enabled engine providers are tried in turn, the first one that
+        accepts is selected. The choice of engine is stored and re-used
+        unless `reset=True`, in which case the selection process is started
+        again.
+        """
+        if hasattr(self, "_engine_provider") and not reset:
+            return self._engine_class(self)
+
         for provider, engine_class in get_engine_classes(
             self._engine_name,
             default=self._default_engine,
         ):
-            if hasattr(self, "_engine_provider") and not reset:
-                if self._engine_provider != provider:
-                    continue
-
             engine = engine_class(self)
-            if engine.accepts(X, y=y):
+            if engine.accepts(X, y=y, sample_weight=sample_weight):
                 self._engine_provider = provider
                 self._engine_class = engine_class
                 return engine
-
-        if hasattr(self, "_engine_provider"):
-            raise RuntimeError(
-                "Estimator was previously fitted with the"
-                f" {self._engine_provider} engine, but it is not available. Currently"
-                f" configured engines: {get_config()['engine_provider']}"
-            )
 
 
 def is_classifier(estimator):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1004,24 +1004,17 @@ class EngineAwareMixin:
         again.
         """
         if hasattr(self, "_engine_provider") and not reset:
-            return self._engine_class(self), {
-                "X": X,
-                "y": y,
-                "sample_weight": sample_weight,
-            }
+            return self._engine_class(self)
 
         for provider, engine_class in get_engine_classes(
             self._engine_name,
             default=self._default_engine,
         ):
             engine = engine_class(self)
-            accepted, validated_inputs = engine.validate(
-                X, y=y, sample_weight=sample_weight
-            )
-            if accepted:
+            if engine.accepts(X, y=y, sample_weight=sample_weight):
                 self._engine_provider = provider
                 self._engine_class = engine_class
-                return engine, validated_inputs
+                return engine
 
 
 def is_classifier(estimator):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1004,6 +1004,13 @@ class EngineAwareMixin:
         again.
         """
         if hasattr(self, "_engine_provider") and not reset:
+            configured_providers = get_config()["engine_provider"]
+            if self._engine_provider not in configured_providers:
+                raise RuntimeError(
+                    f"Previously selected engine ({self._engine_provider}) is no longer"
+                    " configured."
+                )
+
             return self._engine_class(self)
 
         for provider, engine_class in get_engine_classes(

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -23,6 +23,7 @@ from ..base import (
     ClusterMixin,
     TransformerMixin,
     ClassNamePrefixFeaturesOutMixin,
+    EngineAwareMixin,
 )
 from ..metrics.pairwise import euclidean_distances
 from ..metrics.pairwise import _euclidean_distances
@@ -54,8 +55,6 @@ from ._k_means_elkan import init_bounds_dense
 from ._k_means_elkan import init_bounds_sparse
 from ._k_means_elkan import elkan_iter_chunked_dense
 from ._k_means_elkan import elkan_iter_chunked_sparse
-from .._config import get_config
-from .._engine import get_engine_classes
 
 
 ###############################################################################
@@ -1297,7 +1296,7 @@ class _BaseKMeans(
         }
 
 
-class KMeans(_BaseKMeans):
+class KMeans(_BaseKMeans, EngineAwareMixin):
     """K-Means clustering.
 
     Read more in the :ref:`User Guide <k_means>`.
@@ -1471,6 +1470,9 @@ class KMeans(_BaseKMeans):
         ],
     }
 
+    _engine_name = "kmeans"
+    _default_engine = KMeansCythonEngine
+
     def __init__(
         self,
         n_clusters=8,
@@ -1516,26 +1518,6 @@ class KMeans(_BaseKMeans):
             )
             self._algorithm = "lloyd"
 
-    def _get_engine(self, X, y=None, sample_weight=None, reset=False):
-        for provider, engine_class in get_engine_classes(
-            "kmeans", default=KMeansCythonEngine
-        ):
-            if hasattr(self, "_engine_provider") and not reset:
-                if self._engine_provider != provider:
-                    continue
-
-            engine = engine_class(self)
-            if engine.accepts(X, y=y, sample_weight=sample_weight):
-                self._engine_provider = provider
-                return engine
-
-        if hasattr(self, "_engine_provider"):
-            raise RuntimeError(
-                "Estimator was previously fitted with the"
-                f" {self._engine_provider} engine, but it is not available. Currently"
-                f" configured engines: {get_config()['engine_provider']}"
-            )
-
     def _warn_mkl_vcomp(self, n_active_threads):
         """Warn when vcomp and mkl are both present"""
         warnings.warn(
@@ -1571,6 +1553,8 @@ class KMeans(_BaseKMeans):
         self : object
             Fitted estimator.
         """
+        super().fit(X, y=y, sample_weight=sample_weight)
+        print("SDFSDSDFSDFSDF")
         self._validate_params()
         engine = self._get_engine(X, y, sample_weight, reset=True)
 

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -306,9 +306,18 @@ class KMeansCythonEngine:
     def __init__(self, estimator):
         self.estimator = estimator
 
-    def accepts(self, X, y=None, sample_weight=None):
-        # The default engine accepts everything
-        return True
+    def validate(self, X, y=None, sample_weight=None):
+        """Validate input and hyper-parameters.
+
+        Determine if the engine can handle the hyper-parameter of the estimator
+        as well as the input data. Input data may be converted and then validated,
+
+        Return the acceptance decision and a dictionary containing the input data.
+
+        Should fail as quickly as possible.
+        """
+        # The default engine accepts everything and does not convert inputs
+        return True, {"X": X, "y": y, "sample_weight": sample_weight}
 
     def prepare_fit(self, X, y=None, sample_weight=None):
         estimator = self.estimator
@@ -1584,14 +1593,16 @@ class KMeans(_BaseKMeans, EngineAwareMixin):
             Fitted estimator.
         """
         self._validate_params()
-        engine = self._get_engine(X, y, sample_weight, reset=True)
+        engine, validated_inputs = self._get_engine(X, y, sample_weight, reset=True)
 
+        X = validated_inputs["X"]
+        y = validated_inputs["y"]
+        sample_weight = validated_inputs["sample_weight"]
         X, y, sample_weight = engine.prepare_fit(
             X,
             y=y,
             sample_weight=sample_weight,
         )
-        self._check_params_vs_input(X)
 
         best_inertia, best_labels = None, None
 
@@ -1663,7 +1674,10 @@ class KMeans(_BaseKMeans, EngineAwareMixin):
             Index of the cluster each sample belongs to.
         """
         check_is_fitted(self)
-        engine = self._get_engine(X)
+        engine, validated_inputs = self._get_engine(X, sample_weight=sample_weight)
+        X = validated_inputs["X"]
+        y = validated_inputs["y"]
+        sample_weight = validated_inputs["sample_weight"]
         X, sample_weight = engine.prepare_prediction(X, sample_weight)
         return engine.get_labels(X, sample_weight)
 
@@ -1690,8 +1704,8 @@ class KMeans(_BaseKMeans, EngineAwareMixin):
             X transformed in the new space.
         """
         self.fit(X, sample_weight=sample_weight)
-        engine = self._get_engine(X, y=y, sample_weight=sample_weight)
-        return self._transform(X, engine)
+        engine, validated_inputs = self._get_engine(X, y=y, sample_weight=sample_weight)
+        return self._transform(validated_inputs["X"], engine)
 
     def transform(self, X):
         """Transform X to a cluster-distance space.
@@ -1711,8 +1725,8 @@ class KMeans(_BaseKMeans, EngineAwareMixin):
             X transformed in the new space.
         """
         check_is_fitted(self)
-        engine = self._get_engine(X)
-        X = engine.prepare_transform(X)
+        engine, validated_inputs = self._get_engine(X)
+        X = engine.prepare_transform(validated_inputs["X"])
         return self._transform(X, engine)
 
     def _transform(self, X, engine):
@@ -1740,7 +1754,9 @@ class KMeans(_BaseKMeans, EngineAwareMixin):
             Opposite of the value of X on the K-means objective.
         """
         check_is_fitted(self)
-        engine = self._get_engine(X, y=y, sample_weight=sample_weight)
+        engine, validated_inputs = self._get_engine(X, y=y, sample_weight=sample_weight)
+        X = validated_inputs["X"]
+        sample_weight = validated_inputs["sample_weight"]
 
         X, sample_weight = engine.prepare_prediction(X, sample_weight)
 

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -277,9 +277,20 @@ class KMeansCythonEngine:
 
     @staticmethod
     def convert_to_numpy(name, value):
-        """Convert estimator attributes to numpy arrays
+        """Convert estimator attributes to Numpy arrays
 
-        Works for normal numpy arrays and 'array API' arrays.
+        Parameters
+        ----------
+        name : str
+            Name of the attribute being converted.
+
+        value
+            Value of the attribute being converted.
+
+        Returns
+        --------
+        converted : ndarray
+            Attribute value converted to a ndarray
         """
         # XXX Maybe a bit useless as it should never get called, but it
         # does demonstrate the API

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -276,8 +276,15 @@ class KMeansCythonEngine:
     """
 
     @staticmethod
-    def convert_to_numpy(name, value):
-        """Convert estimator attributes to Numpy arrays
+    def convert_to_sklearn_types(name, value):
+        """Convert estimator attributes to scikit-learn types.
+
+        Users can configure whether estimator attributes should be stored
+        using engine native types or scikit-learn types. This function is
+        used to convert attributes from engine to scikit-learn native types.
+
+        Scikit-learn native types are ndarrays and basic Python types. There
+        is no need to convert these.
 
         Parameters
         ----------
@@ -289,12 +296,12 @@ class KMeansCythonEngine:
 
         Returns
         --------
-        converted : ndarray
-            Attribute value converted to a ndarray
+        converted
+            Attribute value converted to a scikit-learn native type.
         """
         # XXX Maybe a bit useless as it should never get called, but it
         # does demonstrate the API
-        return np.asarray(value)
+        return value
 
     def __init__(self, estimator):
         self.estimator = estimator

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -25,6 +25,7 @@ from ..base import (
     ClassNamePrefixFeaturesOutMixin,
     EngineAwareMixin,
 )
+from .._engine import convert_attributes
 from ..metrics.pairwise import euclidean_distances
 from ..metrics.pairwise import _euclidean_distances
 from ..utils.extmath import row_norms, stable_cumsum
@@ -273,6 +274,16 @@ class KMeansCythonEngine:
 
     TODO: see URL for more details.
     """
+
+    @staticmethod
+    def convert_to_numpy(name, value):
+        """Convert estimator attributes to numpy arrays
+
+        Works for normal numpy arrays and 'array API' arrays.
+        """
+        # XXX Maybe a bit useless as it should never get called, but it
+        # does demonstrate the API
+        return np.asarray(value)
 
     def __init__(self, estimator):
         self.estimator = estimator
@@ -1527,6 +1538,7 @@ class KMeans(_BaseKMeans, EngineAwareMixin):
             f" variable OMP_NUM_THREADS={n_active_threads}."
         )
 
+    @convert_attributes
     def fit(self, X, y=None, sample_weight=None):
         """Compute k-means clustering.
 
@@ -1553,8 +1565,6 @@ class KMeans(_BaseKMeans, EngineAwareMixin):
         self : object
             Fitted estimator.
         """
-        super().fit(X, y=y, sample_weight=sample_weight)
-        print("SDFSDSDFSDFSDF")
         self._validate_params()
         engine = self._get_engine(X, y, sample_weight, reset=True)
 

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -307,10 +307,13 @@ class KMeansCythonEngine:
         self.estimator = estimator
 
     def accepts(self, X, y=None, sample_weight=None):
-        """Validate input and hyper-parameters.
+        """Determine if input data and hyper-parameters are supported by
+        this engine.
 
-        Determine if the engine can handle the hyper-parameter of the estimator
-        as well as the input data.
+        Determine if this engine can handle the hyper-parameters of the
+        estimator as well as the input data. If not, return `False`. This
+        method is called during engine selection where each enabled engine
+        is tried in the user defined order.
 
         Should fail as quickly as possible.
         """


### PR DESCRIPTION
Adds a mixin for estimators to use when they support having an engine. 

Also adds a decorator that can be used on `fit` to convert the estimators attributes to either `engine_native` or `sklearn_native` types.

WDYT?

Notes: I considered using something like `__init_subclass__` to automagically wrap `fit` but decided that "explicit is better than implicit", so this is how we got the decorator approach. After building something based on `__init_subclass__`, which seemed cool because it means all you have to do is add the mixin, it seemed a bit too magical that this would wrap `fit`. So I switched to having a decorator.