### PR TITLE
Investigate the impact of LU-variants on randomized SVD with scipy's lu_no_fortran branch

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -277,9 +277,22 @@ def randomized_range_finder(
         elif power_iteration_normalizer == "LU":
             Q, _ = linalg.lu(safe_sparse_dot(A, Q), permute_l=True)
             Q, _ = linalg.lu(safe_sparse_dot(A.T, Q), permute_l=True)
+        elif power_iteration_normalizer == "LU_indices":
+            permutation, Q, _ = linalg.lu(safe_sparse_dot(A, Q), matrix_p=False)
+            Q = Q[permutation]
+            permutation, Q, _ = linalg.lu(safe_sparse_dot(A.T, Q), matrix_p=False)
+            Q = Q[permutation]
+        elif power_iteration_normalizer == "LU_no_permute":
+            _, Q, _ = linalg.lu(safe_sparse_dot(A, Q), matrix_p=False)
+            _, Q, _ = linalg.lu(safe_sparse_dot(A.T, Q), matrix_p=False)
         elif power_iteration_normalizer == "QR":
             Q, _ = linalg.qr(safe_sparse_dot(A, Q), mode="economic")
             Q, _ = linalg.qr(safe_sparse_dot(A.T, Q), mode="economic")
+        else:
+            raise ValueError(
+                "Unrecognized value for "
+                f"power_iteration_normalizer: {power_iteration_normalizer}"
+            )
 
     # Sample the range of A using by linear projection of Q
     # Extract an orthonormal basis


### PR DESCRIPTION
Experiment with the `lu_no_fortan` branch of scipy (https://github.com/scipy/scipy/pull/18358) to:

- evaluate the impact of using index-based permutation in the randomized SVD solver of scikit-learn
- explore the impact of discarding the permutation info and therefore confirming @tygert's intuitions expressed in https://github.com/data-apis/array-api/issues/627#issuecomment-1557700781.

Here are the resulting plots of the randomized SVD benchmarks with various normalizers:

![pca_uncorrelated_matrix](https://github.com/ogrisel/scikit-learn/assets/89061/09b65762-5b42-4309-a1c2-1a45221ce28b)
![pca_a3a](https://github.com/ogrisel/scikit-learn/assets/89061/2f40f101-df3f-4f8d-914e-9385b559cbbc)
![pca_mnist_784](https://github.com/ogrisel/scikit-learn/assets/89061/ba5abe9f-9577-48cd-a6d0-dc885d1f430f)
![pca_20newsgroups](https://github.com/ogrisel/scikit-learn/assets/89061/1e16c7c6-95d2-4c13-9d51-b1ab7dfe29ac)
![pca_olivetti_faces](https://github.com/ogrisel/scikit-learn/assets/89061/2eb50c4a-6ea8-48dc-9bac-f2951a34e05b)
![pca_lfw_people](https://github.com/ogrisel/scikit-learn/assets/89061/2cf2ae90-d93d-43ac-969f-04ed893d1e41)
![pca_low_rank_matrix](https://github.com/ogrisel/scikit-learn/assets/89061/e1b15ae5-b4a1-4155-8c9b-aa47a9debae5)

So in conclusion:

- Using LU-based normalization while completely discarding the permutation info is sometimes better and sometimes worse (!!!) than no normalization at all, but always worse than an LU-based normalizer that takes the permutation into account one way or another.
- Using index-based permutation (using `matrix_p=False` followed by row-wise fancing indexing) seems to be approximately as fast as letting scipy precompute the permutation with `permute_l=True`).
- LU-based normalization with the new Cython-based scipy branch is still slightly faster than QR-based normalization (on average).
